### PR TITLE
Added new field timestamp for local time .which makes it compatible w…

### DIFF
--- a/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/LogEntry.cs
+++ b/src/Serilog.Sinks.MongoDB/Sinks/MongoDB/LogEntry.cs
@@ -33,6 +33,8 @@ public class LogEntry
 
     public DateTime UtcTimeStamp { get; set; }
 
+    public DateTime TimeStamp { get; set; }
+
     public MessageTemplate? MessageTemplate { get; set; }
 
     public string? RenderedMessage { get; set; }
@@ -51,6 +53,7 @@ public class LogEntry
             RenderedMessage = logEvent.RenderMessage(),
             Level = logEvent.Level,
             UtcTimeStamp = logEvent.Timestamp.ToUniversalTime().UtcDateTime,
+            TimeStamp = logEvent.Timestamp.DateTime,
             Exception = logEvent.Exception?.ToBsonDocument().SanitizeDocumentRecursive(),
             Properties = BsonDocument.Create(
                 logEvent.Properties.ToDictionary(


### PR DESCRIPTION
There is Serilog-UI project for mongo db sink which is relying on field Timestamp for sorting but current in the Logentry class name is UtcTimeStamp. I have added one extra field to make it compatible with that and make it as local time instead of UTC.