### PR TITLE
fix: use utc time for rolling interval collection name (#101)

### DIFF
--- a/src/Serilog.Sinks.MongoDB/Helpers/RollingIntervalHelper.cs
+++ b/src/Serilog.Sinks.MongoDB/Helpers/RollingIntervalHelper.cs
@@ -33,7 +33,7 @@ internal static class RollingIntervalHelper
         if (interval == RollingInterval.Infinite) return collectionName;
 
         return
-            $"{collectionName}_{DateTime.Now.ToString(GetDateTimeFormatForInterval(interval), CultureInfo.InvariantCulture)}";
+            $"{collectionName}_{DateTime.UtcNow.ToString(GetDateTimeFormatForInterval(interval), CultureInfo.InvariantCulture)}";
     }
 
     internal static string GetDateTimeFormatForInterval(this RollingInterval interval)


### PR DESCRIPTION
Use Datetime.UtcNow for collection names.

fixes #101 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collection name generation to use UTC time instead of local time, ensuring consistent naming across different timezones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->