### PR TITLE
Expiry / TTL and ExcludeMessageTemplate support in AppSettings

### DIFF
--- a/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
+++ b/src/Serilog.Sinks.MongoDB/LoggerConfigurationMongoDBExtensions.cs
@@ -43,6 +43,8 @@ public static class LoggerConfigurationMongoDBExtensions
     /// <param name="cappedMaxSizeMb"></param>
     /// <param name="cappedMaxDocuments"></param>
     /// <param name="rollingInterval"></param>
+    /// <param name="expireTtl">Allow setting a TTL (Time-To-Live) for log documents in the collection.</param>
+    /// <param name="excludeMessageTemplate">Allow excluding the message template from the log documents.</param>
     /// <returns></returns>
     public static LoggerConfiguration MongoDBBson(
         this LoggerSinkConfiguration loggerConfiguration,
@@ -53,7 +55,9 @@ public static class LoggerConfigurationMongoDBExtensions
         TimeSpan? period = null,
         long? cappedMaxSizeMb = null,
         long? cappedMaxDocuments = null,
-        RollingInterval? rollingInterval = null)
+        RollingInterval? rollingInterval = null,
+        TimeSpan? expireTtl = null,
+        bool excludeMessageTemplate = false)
     {
         var cfg = new MongoDBSinkConfiguration();
 
@@ -69,6 +73,8 @@ public static class LoggerConfigurationMongoDBExtensions
                 cappedMaxDocuments);
 
         if (rollingInterval.HasValue) cfg.SetRollingInterval(rollingInterval.Value);
+        if (expireTtl.HasValue) cfg.SetExpireTTL(expireTtl.Value);
+        if (excludeMessageTemplate) cfg.SetExcludeMessageTemplate(excludeMessageTemplate);
 
         cfg.Validate();
 

--- a/test/Serilog.Sinks.MongoDB.Tests/LoggerConfigurationMongoDBExtensionsTests.cs
+++ b/test/Serilog.Sinks.MongoDB.Tests/LoggerConfigurationMongoDBExtensionsTests.cs
@@ -107,4 +107,83 @@ public class LoggerConfigurationMongoDbExtensionsTests
 
         mongoClient.DropDatabase(MongoDatabaseName);
     }
+
+    [Test]
+    public void Create_Ttl_Index_From_Configuration_ExpireTtl_Flag()
+    {
+        var expireTtl = TimeSpan.FromMinutes(5);
+        const string collectionName = "test-ttl-from-config";
+        const string message = "ttl-index-from-config";
+
+        var configurationValues = new Dictionary<string, string?>(GetSerilogMongoConfiguration())
+        {
+            ["Serilog:WriteTo:0:Args:collectionName"] = collectionName,
+            ["Serilog:WriteTo:0:Args:rollingInterval"] = "Infinite",
+            ["Serilog:WriteTo:0:Args:expireTtl"] = expireTtl.ToString("c")
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("serilog.json")
+            .AddInMemoryCollection(configurationValues)
+            .Build();
+
+        using (var logger = new LoggerConfiguration()
+                   .ReadFrom.Configuration(configuration)
+                   .CreateLogger())
+        {
+            logger.Information(message);
+        }
+
+        var (mongoClient, mongoDatabase) = GetDatabase();
+
+        var mongoCollection = mongoDatabase.GetCollection<BsonDocument>(collectionName);
+        var indexes = mongoCollection.Indexes.List().ToList();
+
+        var ttlIndex = indexes.SingleOrDefault(i =>
+            i.Contains("name") && i["name"].AsString == "serilog_sink_expired_ttl");
+
+        ttlIndex.Should().NotBeNull();
+        ttlIndex!["expireAfterSeconds"].ToDouble().Should().Be(expireTtl.TotalSeconds);
+
+        mongoClient.DropDatabase(MongoDatabaseName);
+    }
+
+    [Test]
+    public void Exclude_MessageTemplate_From_Configuration_Flag()
+    {
+        const string collectionName = "test-exclude-template-from-config";
+        const string template = "Order {OrderId} processed";
+        const int orderId = 42;
+
+        var configurationValues = new Dictionary<string, string?>(GetSerilogMongoConfiguration())
+        {
+            ["Serilog:WriteTo:0:Args:collectionName"] = collectionName,
+            ["Serilog:WriteTo:0:Args:rollingInterval"] = "Infinite",
+            ["Serilog:WriteTo:0:Args:excludeMessageTemplate"] = "true"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("serilog.json")
+            .AddInMemoryCollection(configurationValues)
+            .Build();
+
+        using (var logger = new LoggerConfiguration()
+                   .ReadFrom.Configuration(configuration)
+                   .CreateLogger())
+        {
+            logger.Information(template, orderId);
+        }
+
+        var (mongoClient, mongoDatabase) = GetDatabase();
+        var mongoCollection = mongoDatabase.GetCollection<BsonDocument>(collectionName);
+
+        var document = mongoCollection.Find(new BsonDocument()).FirstOrDefault();
+
+        document.Should().NotBeNull();
+        document!.Contains("MessageTemplate").Should().BeFalse();
+        document.Contains("RenderedMessage").Should().BeTrue();
+        document["RenderedMessage"].AsString.Should().Be("Order 42 processed");
+
+        mongoClient.DropDatabase(MongoDatabaseName);
+    }
 }


### PR DESCRIPTION
- Feature: Added Expiry / TTL support in AppSettings (MongoDBBson only)
- Feature: Added ExcludeMessageTemplate support in AppSettings (MongoDBBson only)
- Test: Added configuration test for TTL support
- Test: Added configuration test for ExcludeMessageTemplate support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `expireTtl` configuration option to set document expiration time for MongoDB logs
  * Added `excludeMessageTemplate` configuration option to exclude message templates from logged documents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->